### PR TITLE
サイドバーのスクロールの実装

### DIFF
--- a/app/assets/stylesheets/wants.scss
+++ b/app/assets/stylesheets/wants.scss
@@ -4,6 +4,7 @@
 body{
   padding-top: 70px;
 }
+
 .wrapper {
   width: 100%;
   height: 100%;
@@ -22,6 +23,7 @@ body{
 
 .sidebar {
   background-color: #9F1717;
+  overflow: scroll;
   width: 300px;
   height: 100%;
   color: #fff;
@@ -58,7 +60,7 @@ div.mapview {
   margin: 10px
 }
 
-p.button-delete{
+p.button-delete {
   text-align: right;
   margin-right: 0;
 }


### PR DESCRIPTION
カテゴリが増えたときにサイドバー全体をスクロールさせることはできました。

サイドバー上部の検索ウィンドウがスクロールした際に消えるのはどうなのかな？と思ってます。
カテゴリのところにだけスクロール適用しようとしてたんですけどカテゴリのテーブル要素の高さ指定が上手くいかなかったので、とりあえずやめました。

スクロールを強くしたときに上と下に赤い背景がチラつくのは原因がよくわかってないです。